### PR TITLE
Allow B.3.3 hoisting through conflicting catch binding

### DIFF
--- a/src/scope-state.js
+++ b/src/scope-state.js
@@ -178,7 +178,13 @@ export default class ScopeState {
     let pvsfd = merge(new MultiMap, this.potentiallyVarScopedFunctionDeclarations);
     let children = this.children;
 
+    let hasSimpleCatchBinding = scopeType.name === 'Catch' && astNode.binding.type === 'BindingIdentifier';
     this.blockScopedDeclarations.forEachEntry((v, k) => {
+      if (hasSimpleCatchBinding && v.length === 1 && v[0].node === astNode.binding) {
+        // A simple catch binding is the only type of lexical binding which does *not* block B.3.3 hoisting.
+        // See B.3.5: https://tc39.github.io/ecma262/#sec-variablestatements-in-catch-blocks
+        return;
+      }
       pvsfd.delete(k);
     });
     this.functionDeclarations.forEachEntry((v, k) => {

--- a/test/unit.js
+++ b/test/unit.js
@@ -1816,7 +1816,7 @@ suite('unit', () => {
       !function(){
         try {} catch(e/* declares e#1 */) {
           {
-            function e/* declares e#2 */() {}
+            function e/* declares e#0, e#2 */() {}
           }
         }
         e/* reads e#0 */;


### PR DESCRIPTION
Fixes #33.

Note that hoisting is still blocked for non-simple parameters (as confirmed by the test following the test this PR changes).