### PR TITLE
properly mark parameter expressions for computed property bindings

### DIFF
--- a/src/scope-analyzer.js
+++ b/src/scope-analyzer.js
@@ -83,6 +83,14 @@ export default class ScopeAnalyzer extends MonoidalReducer {
     return s;
   }
 
+  reduceBindingPropertyProperty(node, { name, binding }) {
+    const s = super.reduceBindingPropertyProperty(node, { name, binding });
+    if (node.name.type === 'ComputedPropertyName') {
+      return s.withParameterExpressions();
+    }
+    return s;
+  }
+
   reduceBindingWithDefault(node, { binding, init }) {
     return super.reduceBindingWithDefault(node, { binding, init }).withParameterExpressions();
   }

--- a/test/unit.js
+++ b/test/unit.js
@@ -1890,6 +1890,19 @@ suite('unit', () => {
     );
   });
 
+  test.only('binding property', () => {
+    checkScopeAnnotation(`/* Scope (Global) declaring a#0 *//* Scope (Script) */
+      !/* Scope (Parameters) declaring arguments#0, b#0 *//* Scope (Function) declaring a#1 */function (
+        /* Scope (ParameterExpression) */{ [a/* reads a#0 */]: b/* declares b#0 */ }/* end scope */
+       ){
+         var a/* declares a#1 */;
+       }/* end scope *//* end scope */
+      /* end scope *//* end scope */`,
+      { skipUnambiguous: false, skipScopes: false }
+    );
+  });
+
+
   test('switch', () => {
     checkScopeAnnotation(`
       switch (x/* reads x#0 */) {

--- a/test/unit.js
+++ b/test/unit.js
@@ -1890,7 +1890,7 @@ suite('unit', () => {
     );
   });
 
-  test.only('binding property', () => {
+  test('binding property', () => {
     checkScopeAnnotation(`/* Scope (Global) declaring a#0 *//* Scope (Script) */
       !/* Scope (Parameters) declaring arguments#0, b#0 *//* Scope (Function) declaring a#1 */function (
         /* Scope (ParameterExpression) */{ [a/* reads a#0 */]: b/* declares b#0 */ }/* end scope */


### PR DESCRIPTION
When a parameter of a function involves an arbitrary expression, it gets is own scope. We were properly observing that when the expression was a default value for a binding, but you can have an expression even without defaults:

```js
function f({ [a]: b }) {}
```

This PR marks computed properties in object bindings as being expressions.